### PR TITLE
Use dateutil and naive datetimes for date filtering

### DIFF
--- a/dump_gitlab_json.py
+++ b/dump_gitlab_json.py
@@ -20,13 +20,10 @@ from functools import partial
 from io import StringIO
 
 from gitlab import Gitlab as GitLab
-
+from dateutil.parser import parse as parsedate
 
 __version__ = '0.1.0'
 
-
-# The datetime format output by GitLab
-TIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
 
 def get_datetime(date_str):
     ''' Turns a YYYY-MM-DD string into a datetime object '''
@@ -172,15 +169,12 @@ def main(argv=None):
             project_issues = []
             for issue in gen_all_results(git.getprojectissues, project['id'],
                                          per_page=args.page_size):
-                if args.date_filter < datetime.strptime(issue['updated_at'],
-                                                        TIME_FORMAT):
+                if args.date_filter < parsedate(issue['updated_at']).replace(tzinfo=None):
                     project_issues.append(issue)
                 else:
                     for note in git.getissuewallnotes(project['id'],
                                                       issue['id']):
-                        if (args.date_filter <
-                                datetime.strptime(note['created_at'],
-                                                  TIME_FORMAT)):
+                        if args.date_filter < parsedate(issue['updated_at']).replace(tzinfo=None):
                             project_issues.append(issue)
                             break
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-dateutil==2.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+pyapi-gitlab==7.8.5
 python-dateutil==2.5.3


### PR DESCRIPTION
Not sure how GitLab writes its date strings, but I think it may vary based on installation and server configuration.  The previous hard-coded format string failed for me with:

```
ValueError: time data '2016-04-21T15:09:38.552-07:00' does not match format '%Y-%m-%dT%H:%M:%S.%fZ'
```

I don't know of a good native fix for this, as `strptime` does not seem to support the above style of timezone off-set formatting, so I think it may be worth adding the trusty [python-dateutil](https://labix.org/python-dateutil) package to the dependencies for all-purpose date string parsing.

I'm also not sure how this script ever worked since the default date filter is naive and the format string is timezone aware.  So I stripped `tzinfo` from the GL time data, since the expected `date_filter` parameter is `YYYY-MM-DD` anyway.

Sound good?